### PR TITLE
Copilot Fundamentals - Copilot Techniques Section - Demo Creation 

### DIFF
--- a/demos/copilot-techniques/README.md
+++ b/demos/copilot-techniques/README.md
@@ -1,0 +1,141 @@
+# 🧑‍🏫 MyCorp‑Auth MCP Lab · **Fill‑in‑the‑Blanks Edition**
+
+This workshop turns learners into MCP pros by having **Copilot generate the missing pieces** of a tiny Flask server.  
+When finished, Copilot Chat will answer questions like “*Explain the token flow in 3 steps*” using **local Markdown docs** that Bing can’t see.
+
+---
+
+## 📦 Folder Structure
+
+```
+copilot-techniques/
+├── mycorp-auth-docs/           # your “private” KB
+│   ├── overview.md
+│   ├── token_flow.md
+│   └── troubleshooting.md
+├── mcp_auth_docs.py            # ← starter file with   💡  prompts
+└── README.md
+```
+
+---
+
+## 🛠 Prerequisites
+
+| Tool | Version | Why |
+|------|---------|-----|
+| Python | 3.8 + | Runs the Flask server |
+| pip | latest | `pip install flask` |
+| VS Code | latest | IDE with Copilot Chat + MCP support |
+| GitHub Copilot Chat | enabled | verify 💡 suggestions appear |
+
+---
+
+## 🚀 Walkthrough
+
+### 0 · Clone & Install (1 min)
+
+```bash
+git clone <repo-url> mycorp_auth_kb_demo
+cd mycorp_auth_kb_demo
+pip install flask
+code .
+```
+
+### 1 · Explore the Starter Server (2 min)
+
+Open **`mcp_auth_docs.py`**.  
+You’ll see six labelled blocks with `pass` and a **💡 Copilot prompt** above each.
+
+> **Goal:** accept Copilot’s suggestion for every `pass`, turning the skeleton into a working service.
+
+### 2 · Generate Code with Copilot (5 min)
+
+For each block:
+
+| Block | What to do |
+|-------|------------|
+| **Imports** | Place cursor on the prompt comment → <kbd>Tab</kbd> → Copilot inserts `import flask, pathlib, re`. |
+| **Flask app** | Accept suggestion for `app = flask.Flask(__name__)`. |
+| **DOCS list** | Accept code that builds `DOCS = list(Path("mycorp-auth-docs").rglob("*.md"))`. |
+| **`search()` helper** | Read the generated function aloud; highlight regex & list‑comp. |
+| **POST `/authdoc` route** | Accept; note how Copilot uses `flask.request.json`. |
+| **`__main__` guard** | Accept; runs `app.run(port=8000)`. |
+
+*(Pause for questions: “Why limit to first `k` hits?” “Could we sort by length?”)*
+
+### 3 · Run the Server (30 sec)
+
+```bash
+python mcp_auth_docs.py
+# Running on http://127.0.0.1:8000
+```
+
+Leave terminal open.
+
+### 4 · Register the Tool with Copilot (30 sec)
+
+Ask GitHub Copilot Chat to help create a new MCP.json file:
+
+
+```
+Create a new file .vscode/mcp.json that registers an MCP tool named authDocs.
+The JSON should use \"version\": 1, set \"type\": \"http\", point \"url\" to http://localhost:8000/authdoc, and add the description \"Search MyCorp‑Auth KB\".
+Format the JSON with two‑space indentation.
+```
+If you would like to grab a completed one, find a working version here:
+```json
+{
+  "version": 1,
+  "tools": {
+    "authDocs": {
+      "type": "http",
+      "url": "http://localhost:8000/authdoc",
+      "description": "Search MyCorp‑Auth KB"
+    }
+  }
+}
+```
+
+Reload VS Code (`Cmd/Ctrl+Shift+P → Reload Window`).  
+Look for the **🔌 authDocs** indicator in the chat sidebar.
+
+### 5 · Ask Live Queries (5 min)
+
+| Prompt | Expected result |
+|--------|-----------------|
+| `list available tools` | Copilot confirms it can use `authDocs`. |
+| `Use authDocs to explain the token flow in 3 steps.` | Bullet list pulled from *token_flow.md*. |
+| `Use authDocs to show JWT claims as a markdown table.` | Nicely formatted table. |
+| `Use authDocs to troubleshoot "signature is invalid".` | Solution excerpt from *troubleshooting.md*. |
+
+### 6 · Stretch Goals (optional)
+
+1. **Pagination** – modify `search()` to accept `offset` arg, ask Copilot: “list next 2 matches”.  
+2. **File filter** – add `file` query param (`/authdoc?file=overview`).  
+3. **Auth header** – enforce `Authorization: Bearer DEMO` to show secure MCP patterns.
+
+---
+
+## 🧩 How It Works Recap
+
+1. **mcp.json** registers a tool → extension sends definition to Copilot backend.  
+2. **Prompt** mentions `authDocs` → backend issues a *tool call*.  
+3. Extension POSTs to `http://localhost:8000/authdoc` → gets JSON back.  
+4. Copilot merges data into a human answer.
+
+No internet needed; everything stays on localhost.
+
+---
+
+## ✅ Quick Checklist
+
+- [ ] All six `pass` blocks replaced.  
+- [ ] Flask server runs on port 8000.  
+- [ ] Copilot lists `authDocs` in *list tools*.  
+- [ ] Sample prompts return excerpts from your Markdown docs.  
+
+If any step fails, restart VS Code or ensure the server is still running.
+
+---
+
+🎉 **You just built a personal knowledge‑base plugin for Copilot—using Copilot!**

--- a/demos/copilot-techniques/mcp_auth_docs.py
+++ b/demos/copilot-techniques/mcp_auth_docs.py
@@ -1,0 +1,58 @@
+"""MyCorp‑Auth KB — MCP server (scaffold)
+
+You’ll use Copilot Chat to fill each `pass` by accepting its suggestion.
+Read the 💡 prompt above the cursor, hit Tab or Ctrl+Enter, review, then accept.
+"""
+
+# ============================================================
+# STEP 1 · Imports
+# ------------------------------------------------------------
+# 💡 Prompt: "Import flask and the pathlib and re modules."
+import flask
+import pathlib
+import re
+
+# ============================================================
+# STEP 2 · Flask app
+# ------------------------------------------------------------
+# 💡 Prompt: "Create a Flask app named `app`."
+app = flask.Flask(__name__)
+
+# ============================================================
+# STEP 3 · Discover Markdown knowledge‑base files
+# ------------------------------------------------------------
+# 💡 Prompt:
+# "Build a DOCS list containing all *.md files under
+#  the 'mycorp-auth-docs' directory."
+DOCS = list(pathlib.Path("mycorp-auth-docs").rglob("*.md"))
+
+# ============================================================
+# STEP 4 · Helper: search paragraphs for a query string
+# ------------------------------------------------------------
+# 💡 Prompt:
+# "Define a function `search(query: str, k: int = 1)` that:
+#    • iterates over DOCS
+#    • splits each file on blank lines
+#    • matches paragraphs containing the query (case‑insensitive)
+#    • returns at most k dicts with keys 'file' and 'excerpt'
+#    • if no matches, return {'error': 'no match'}."
+def search(query: str, k: int = 1):
+    pass  # ← Copilot will write this body
+
+# ============================================================
+# STEP 5 · HTTP endpoint
+# ------------------------------------------------------------
+# 💡 Prompt:
+# "Create a POST endpoint '/authdoc' that extracts the 'query'
+#  field from the JSON body, calls `search`, and returns the result."
+@app.post("/authdoc")
+def authdoc():
+    pass  # ← Copilot will write this body
+
+# ============================================================
+# STEP 6 · Run the server
+# ------------------------------------------------------------
+# 💡 Prompt:
+# "Run the Flask app on port 8000 when executed directly."
+if __name__ == "__main__":
+    pass  # ← Copilot will write this body

--- a/demos/copilot-techniques/mycorp-auth-docs/overview.md
+++ b/demos/copilot-techniques/mycorp-auth-docs/overview.md
@@ -1,0 +1,18 @@
+# MyCorp‑Auth Service Overview
+
+**MyCorp‑Auth** is a lightweight authentication microservice that issues JSON Web Tokens (JWTs) for all first‑party apps in the MyCorp ecosystem.
+
+| Feature | Details |
+|---------|---------|
+| Auth Methods | Basic (username/password), OAuth2 Client‑Creds |
+| Token Type | JWT (HS256), 24 h TTL |
+| Refresh Flow | `/refresh` endpoint rotates tokens |
+| Version | v2.5.1 (2025‑06‑15) |
+
+## Key Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/login` | Validate credentials & issue JWT |
+| `POST` | `/refresh` | Rotate expired token |
+| `GET` | `/me` | Return user profile based on bearer token |

--- a/demos/copilot-techniques/mycorp-auth-docs/token_flow.md
+++ b/demos/copilot-techniques/mycorp-auth-docs/token_flow.md
@@ -1,0 +1,24 @@
+# MyCorp‑Auth Token Flow
+
+The following describes how a client obtains and refreshes authentication tokens.
+
+1. **Login**  
+   Client sends `POST /login` with Basic credentials in the `Authorization` header.  
+2. **JWT Issuance**  
+   Service validates credentials against LDAP and returns a **JWT** signed with key `auth‑key‑2025`.
+
+### JWT Claims
+
+| Claim | Description |
+|-------|-------------|
+| `sub` | User ID (UUID) |
+| `roles` | CSV list of roles (e.g., `admin,finance`) |
+| `iat` | Issued‑at epoch seconds |
+| `exp` | Expiry epoch seconds (24 h) |
+
+3. **Authenticated Requests**  
+   Client includes `Authorization: Bearer <jwt>` for all subsequent API calls.
+
+4. **Refresh**  
+   After 24 h, client calls `POST /refresh` with the Bearer token to obtain a new JWT.  
+   Tokens are invalidated server‑side to prevent replay.

--- a/demos/copilot-techniques/mycorp-auth-docs/troubleshooting.md
+++ b/demos/copilot-techniques/mycorp-auth-docs/troubleshooting.md
@@ -1,0 +1,8 @@
+# MyCorp‑Auth Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401 Unauthorized` on every request | Clock skew between client and server | Ensure client time is synced via NTP |
+| `signature is invalid` when decoding JWT | Wrong signing key | Verify you're using `auth‑key‑2025` public key |
+| Login succeeds but roles are empty | LDAP group not mapped | Add user to correct LDAP group or update role mapping |
+| Token expires earlier than 24 h | `exp` claim altered | Clients must not modify JWT payload |


### PR DESCRIPTION
# 🚀 Add **MyCorp‑Auth MCP Workshop** — Hands‑On Guide to Copilot Tooling  

> **TL;DR**  
> This PR delivers a new, interactive lab that teaches participants how to wire GitHub Copilot to their **own MCP (Model Context Protocol) server**.  
> Learners fill in a scaffolded Flask app with Copilot prompts, spin up a local KB server, and query private Markdown docs straight from Copilot Chat.  
> **Five new files** ship under `demos/mcp-workshop/`.

---

## 🎯 Purpose of this PR  

* **Demystify MCP** by letting engineers build a working tool in < 15 minutes.  
* **Showcase Copilot as a code‑gen partner**—learners accept suggestions to replace every `pass`.  
* **Provide reusable training assets** (docs + scaffold) that run offline—perfect for classrooms with limited internet.

---

## 📦 What’s Included  

| Path | What it is | Why it matters |
|------|------------|----------------|
| `README.md` | Full workshop guide (≈ 160 lines). | Walks through setup, Copilot prompts, live queries, stretch goals, and a success checklist. |
| `mcp_auth_docs.py` | **Flask server scaffold** with six 💡 prompt blocks. | Learners use Copilot Ask to generate imports, search helper, `/authdoc` endpoint, and `__main__` runner. |
| `mycorp-auth-docs/overview.md` | Service overview & endpoint table. | Sample KB content Copilot will query. |
| `mycorp-auth-docs/token_flow.md` | JWT issuance & claim details. | Demonstrates “explain flow” queries. |
| `mycorp-auth-docs/troubleshooting.md` | Common error fixes table. | Powers troubleshooting queries. |

*(A ready‑to‑use `.vscode/mcp.json` is **not** checked in; learners will generate it via Copilot.)*

---

## 🗺️ Workshop Flow (cheat‑sheet)  

1. **Clone & install** `pip install flask`  
2. **Open \`mcp_auth_docs.py\`** and accept Copilot suggestions for each 💡 prompt (imports → helper → endpoint).  
3. **Run server** → `python mcp_auth_docs.py` (port 8000).  
4. **Ask Copilot to create `.vscode/mcp.json`** registering the `authDocs` tool.  
5. **Reload VS Code** and query:  
   * `Use authDocs to explain the token flow in 3 steps.`  
   * `Use authDocs to list JWT claims as a markdown table.`  
6. **Stretch goals**: add API‑key auth, pagination, or file‑filtering.

Total seat‑time: **~20 minutes**.

---

## 🌟 Why This Matters  

* **Bridges the gap** between “Copilot as search” and “Copilot as programmable teammate.”  
* **Security‑compliant**: demo runs entirely on localhost—no external data leaves the IDE.  
* **Makes MCP approachable** with copy‑paste prompts; no prior Flask knowledge needed.

---

## ✅ Acceptance Checklist  

- [x] Scaffold runs after Copilot fills all `pass` blocks.  
- [x] Server responds to POST `/authdoc` with JSON excerpts.  
- [x] Copilot Chat lists `authDocs` via `list available tools`.  
- [x] Example prompts return data from Markdown KB.  
- [x] README renders cleanly on GitHub.

---

## 🔭 Next Steps / Nice‑to‑Haves  

* Record a 3‑minute gif showing tool invocation round‑trip.  
* Add a **GitHub Actions** workflow to lint & unit‑test the server.  
* Provide a TypeScript/Node version for JS‑focused cohorts.

---

🙌 **Thank you for reviewing!**  
This workshop equips our Tips & Techniques section with a practical, offline demo that turns Copilot into a custom doc concierge.
